### PR TITLE
fix heartbeat function to return actual last heartbeat

### DIFF
--- a/samples/file_processing/lib/s3_activity.rb
+++ b/samples/file_processing/lib/s3_activity.rb
@@ -76,7 +76,9 @@ class S3Activity
       # activity_execution_context is available to Activity classes that extend
       # AWS::Flow::Activities
       activity_execution_context.record_activity_heartbeat(progress.to_s)
+      Time.now
+    else
+      last_heartbeat_time
     end
-    Time.now
   end
 end


### PR DESCRIPTION
heartbeat function was returning Time.now regardless of if a heartbeat took place.  This is causing  activity functions to incorrectly set the "last_heartbeat_time" variable and never allowing an actual heartbeat to take place because Time.now and last_heartbeat_time will always be too close to go over the heartbeat delta set in HEARTBEAT_INTERVAL.