### PR TITLE
Revise the deployments example to be a bit more Ruby idiomatic

### DIFF
--- a/samples/deployment/lib/deployment_types.rb
+++ b/samples/deployment/lib/deployment_types.rb
@@ -21,15 +21,25 @@ module Deployable
   end
 
   def deploy(activity_client)
-    deployable_urls = @depends_on.map {|x| x.url } unless @depends_on.nil?
+    deployable_urls = depends_on.map(&:url) unless depends_on
     task do
-      wait_for_all(deployable_urls) unless deployable_urls.nil?
+      wait_for_all(deployable_urls) unless deployable_urls
       url.set(deploy_self(activity_client))
     end
   end
 
   def deploy_self(activity_client)
-    # Fill me in inside a sublass for polymorphic magic!
+    raise "Fill me in inside a sublass for polymorphic magic!"
+  end
+
+  protected
+
+  def extract_urls(hosts)
+    return nil unless hosts
+
+    hosts.each_with_object( [] ) do |host, urls|
+      urls << host.url.get if host.url.is_a? Future
+    end
   end
 end
 
@@ -37,16 +47,14 @@ class LoadBalancer
   include Deployable
 
   attr_accessor :web_servers
+
   def initialize(host, web_servers)
-    @webservers = web_servers
     super host, web_servers, Future.new
+    @web_servers = web_servers
   end
 
   def deploy_self(activity_client)
-    web_server_urls = @web_servers.map { |x|
-      x.url.get if x.url.is_a? Future
-    }.compact unless @web_servers.nil?
-
+    web_server_urls = extract_urls(web_servers)
     activity_client.deploy_load_balancer(web_server_urls)
   end
 
@@ -58,15 +66,12 @@ class AppServer
   attr_accessor :databases
 
   def initialize(host, databases)
-    @databases = databases
     super host, databases, Future.new
+    @databases = databases
   end
 
   def deploy_self(activity_client)
-    data_sources = @databases.map { |x|
-      x.url.get if x.url.is_a? Future
-    }.compact unless @databases.nil?
-
+    data_sources = extract_urls(databases)
     activity_client.deploy_app_server(data_sources)
   end
 end
@@ -76,19 +81,14 @@ class WebServer
   attr_accessor :databases, :app_servers
 
   def initialize(host, databases, app_servers)
+    super host, databases.concat(app_servers), Future.new
     @databases = databases
     @app_servers = app_servers
-    super host, databases.concat(app_servers), Future.new
   end
 
   def deploy_self(activity_client)
-    data_sources = @databases.map { |x|
-      x.url.get if x.url.is_a? Future
-    }.compact unless @databases.nil?
-
-    app_server_urls = @app_servers.map { |x|
-      x.url.get if x.url.is_a? Future
-    }.compact unless @app_servers.nil?
+    data_sources = extract_urls(databases)
+    app_server_urls = extract_urls(app_servers)
 
     activity_client.deploy_web_server(data_sources, app_server_urls)
   end
@@ -107,8 +107,8 @@ class Database
 end
 
 class ApplicationStack
-
   attr_accessor :components, :frontend, :activity_client
+
   def initialize(types)
     @components = types[:components]
     @frontend = types[:frontend]
@@ -116,12 +116,12 @@ class ApplicationStack
   end
 
   def deploy
-    @components.each { |x|
-      x.deploy(@activity_client) if x.is_a? Deployable
-    }
+    components.each do |component|
+      component.deploy(activity_client) if component.is_a? Deployable
+    end
   end
 
   def get_url
-    @frontend.url
+    frontend.url
   end
 end

--- a/samples/deployment/lib/deployment_workflow.rb
+++ b/samples/deployment/lib/deployment_workflow.rb
@@ -68,8 +68,8 @@ class DeploymentWorkflow
     components = [databases, app_servers, web_servers, load_balancers]
 
     # Create the application stack
-    application_stack = ApplicationStack.new( {
-      components: components.map! { |t| t = t.values }.flatten!,
+    application_stack = ApplicationStack.new({
+      components: components.map!(&:values).flatten,
       frontend: frontend,
       activity_client: client
     })
@@ -81,52 +81,45 @@ class DeploymentWorkflow
 
   # Helper method used to create Database objects from a database config
   def build_databases databases
-    result = {}
-    databases.each do |database|
+    databases.each_with_object( {} ) do |database, result|
       result[database["id"].to_sym] = Database.new(database["host"])
     end
-    result
   end
 
   # Helper method used to create AppServer objects from an app server config
   def build_app_servers(app_servers, databases)
-    result = {}
-    app_servers.each do |app_server|
+    app_servers.each_with_object( {} ) do |app_server, result|
       result[app_server["id"].to_sym] = AppServer.new(
         app_server["host"], extract_keys(app_server["database"], databases))
     end
-    result
   end
 
   # Helper method used to create WebServer objects from web server config
   def build_web_servers(web_servers, databases, app_servers)
-    result = {}
-    web_servers.each do |web_server|
+    web_servers.each_with_object do |web_server, result|
       result[web_server["id"].to_sym] = WebServer.new( web_server["host"],
         extract_keys(web_server["database"], databases),
         extract_keys(web_server["app_server"], app_servers))
     end
-    result
   end
 
   # Helper method used to create LoadBalancer objects from a load balancer config
   def build_load_balancers(load_balancers, web_servers)
-    result = {}
-    load_balancers.each do |load_balancer|
+    load_balancers.each_with_object( {} ) do |load_balancer, result|
       result[load_balancer["id"].to_sym] = LoadBalancer.new( load_balancer["host"],
         extract_keys(load_balancer["web_server"], web_servers))
     end
-    result
   end
 
   # Helper method used to create frontend from a load balancer config
   def build_frontend(frontends, load_balancers)
     extract_keys(frontends, load_balancers)
-    #frontends.map {|id| load_balancers[id.to_sym] if load_balancers.key? id.to_sym}
   end
 
   def extract_keys(components, hash)
-    components.map { |id| hash[id.to_sym] if hash.key? id.to_sym }
+    components.each_with_object( [] ) do |id, values|
+      values << hash[id.to_sym] if hash.key? id.to_sym
+    end
   end
 
   # Helper method to check if Flow is replaying the workflow. This is used to


### PR DESCRIPTION
- If you already defined an attr_reader for an instance variable
  `databases`, then you access it via `databases`, too, skipping the
  then-optional `@`.
- You can also express the `result = {}; so_something_with(result);
  result`-pattern via `Enumerable#each_with_object`.
- `enum.map { |x| x.attrib }` and `enum.map(&:attrib)` are
  equivalent, but the latter is shorter.
- Don't use the return value of bang-methode prematurely: `flatten!`,
  for example, returns nil if no modifications were made!
